### PR TITLE
Fixes #83 Added automatic PYTHONPATH append

### DIFF
--- a/bin/infoset-ng-api
+++ b/bin/infoset-ng-api
@@ -16,6 +16,11 @@ from gunicorn.six import iteritems
 
 # Infoset libraries
 try:
+    if "infoset-ng/bin" in str(os.getcwd()):
+        sys.path.append(os.getcwd()[:-4])
+    else :
+        sys.path.append(os.getcwd())
+    
     from infoset.utils import log
 except:
     print('You need to set your PYTHONPATH to include the infoset library')

--- a/bin/infoset-ng-ingester
+++ b/bin/infoset-ng-ingester
@@ -13,6 +13,11 @@ import time
 
 # Infoset libraries
 try:
+    if "infoset-ng/bin" in str(os.getcwd()):
+        sys.path.append(os.getcwd()[:-4])
+    else :
+        sys.path.append(os.getcwd())
+    
     from infoset.agents import agent as Agent
 except:
     print('You need to set your PYTHONPATH to include the infoset library')


### PR DESCRIPTION
This PR adds path to PYTHONPATH automatically and doesn't require this step in the installation process.

```bash
export PYTHONPATH=`pwd`
```
